### PR TITLE
Refactor: Improve file handling and request flow in chat

### DIFF
--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -77,9 +77,10 @@ export function ChatInput({
       e.preventDefault();
 
       if (input.trim() || files.length > 0) {
-        const formEvent = e.nativeEvent as unknown as FormEvent;
-        handleSubmit(formEvent, files.length > 0 ? files : null);
-        setFiles([]);
+        const formEvent = e.nativeEvent as unknown as FormEvent
+        handleSubmit(formEvent, files.length > 0 ? files : null).then(() => {
+          setFiles([])
+        })
       }
     }
   };
@@ -91,8 +92,9 @@ export function ChatInput({
         if (isLoading) {
           onStopGeneration();
         } else {
-          handleSubmit(e, files.length > 0 ? files : null);
-          setFiles([]);
+          handleSubmit(e, files.length > 0 ? files : null).then(() => {
+            setFiles([]);
+          })
         }
       }}
       className="flex flex-col w-full bg-white/80 dark:bg-blue-900/80 backdrop-blur-md rounded-2xl p-2 shadow-md border border-blue-100 dark:border-blue-800/50 mb-2 relative"
@@ -121,7 +123,8 @@ export function ChatInput({
 
         {/* Only show upload button if model supports images, documents or audio */}
         {(selectedModel.capabilities.images ||
-          selectedModel.capabilities.documents) && (
+          selectedModel.capabilities.documents ||
+          selectedModel.capabilities.audio) && (
           <UploadButton
             onFile={addFile}
             maxFiles={MAX_FILES}


### PR DESCRIPTION
- Update `ChatInput` to wait for `handleSubmit` to finish before clearing files.
- Fix model capability checks to show upload button for audio and documents.
- Remove `isAborted` state in `ChatWindow` for better abort handling.
- Enhance error handling in `ChatWindow` with toast notifications.
- Use only the first file for image when multiple files are uploaded.